### PR TITLE
Add skip option to maven configuration.

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/AbstractCoverallsMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/AbstractCoverallsMojo.java
@@ -64,6 +64,12 @@ public abstract class AbstractCoverallsMojo extends AbstractMojo {
     /**
      * File path to write and submit Coveralls data.
      */
+    @Parameter(property = "skipCoveralls", defaultValue = "false")
+    protected boolean skipCoveralls;
+    
+    /**
+     * File path to write and submit Coveralls data.
+     */
     @Parameter(property = "coverallsFile", defaultValue = "${project.build.directory}/coveralls.json")
     protected File coverallsFile;
     
@@ -154,6 +160,9 @@ public abstract class AbstractCoverallsMojo extends AbstractMojo {
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
         try {
+            if(job.isSkipCoveralls()) {
+                return;
+            }
             createEnvironment().setup();
             CoverageParser parser = createCoverageParser(createSourceLoader());
             Job job = createJob();
@@ -227,6 +236,7 @@ public abstract class AbstractCoverallsMojo extends AbstractMojo {
         Git git = new GitRepository(project.getBasedir()).load();
         return new Job()
             .withRepoToken(repoToken)
+            .withSkipCoveralls(skipCoveralls)
             .withServiceName(serviceName)
             .withServiceJobId(serviceJobId)
             .withServiceBuildNumber(serviceBuildNumber)


### PR DESCRIPTION
It enables to skip the target. It can be useful on Travis CI for instance to install all modules's artifact and bypassing tests, coverage and coveralls. (At least I need it for a lib of mine :) )
