### PR TITLE
Made basedir configurable

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
@@ -187,6 +187,12 @@ public class CoverallsReportMojo extends AbstractMojo {
     @Component
     protected MavenProject project;
     
+    /**
+     * Scan subdirectories for a sources file.
+     */
+    @Parameter(property = "coveralls.basedir", defaultValue = "${project.basedir}")
+    protected File basedir;
+
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
@@ -275,7 +281,7 @@ public class CoverallsReportMojo extends AbstractMojo {
      * @throws IOException if an I/O error occurs
      */
     protected Job createJob() throws IOException {
-        Git git = new GitRepository(project.getBasedir()).load();
+        Git git = new GitRepository(basedir).load();
         return new Job()
             .withRepoToken(repoToken)
             .withServiceName(serviceName)

--- a/src/test/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojoTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojoTest.java
@@ -187,6 +187,7 @@ public class CoverallsReportMojoTest {
         mojo.coverallsFile = folder.newFile();
         mojo.dryRun = true;
         mojo.skip = false;
+        mojo.basedir = TestIoUtil.getFile("/");
         
         when(projectMock.getBasedir()).thenReturn(TestIoUtil.getFile("/"));
         


### PR DESCRIPTION
This is usefull when using submodules.... otherwise, coveralls-maven-plugin will submit all data to submodule git repository, not the master one!