### PR TITLE
Merge coverage results from serveral report files

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
@@ -1,5 +1,13 @@
 package org.eluder.coveralls.maven.plugin;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 /*
  * #[license]
  * coveralls-maven-plugin
@@ -53,17 +61,8 @@ import org.eluder.coveralls.maven.plugin.service.Shippable;
 import org.eluder.coveralls.maven.plugin.service.Travis;
 import org.eluder.coveralls.maven.plugin.source.SourceCallback;
 import org.eluder.coveralls.maven.plugin.source.SourceLoader;
-import org.eluder.coveralls.maven.plugin.source.UniqueSourceCallback;
 import org.eluder.coveralls.maven.plugin.util.CoverageParsersFactory;
 import org.eluder.coveralls.maven.plugin.util.SourceLoaderFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
 @Mojo(name = "report", threadSafe = false, aggregator = true)
 public class CoverallsReportMojo extends AbstractMojo {
@@ -334,7 +333,6 @@ public class CoverallsReportMojo extends AbstractMojo {
             chain = coverageTracingReporter;
             reporters.add(coverageTracingReporter);
         }
-        chain = new UniqueSourceCallback(chain);
         return chain;
     }
     

--- a/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
@@ -95,4 +95,14 @@ public final class Source implements JsonObject {
         }
         this.coverage[lineNumber - 1] = coverage;
     }
+
+    public void merge(final Source source) {
+        for (int i = 0; i < this.coverage.length && i < source.coverage.length; i++) {
+            if (this.coverage[i] == null && source.coverage[i] != null) {
+                this.coverage[i] = source.coverage[i];
+            } else if (this.coverage[i] != null && source.coverage[i] != null) {
+                this.coverage[i] += source.coverage[i];
+            }
+        }
+    }
 }

--- a/src/test/java/org/eluder/coveralls/maven/plugin/json/JsonWriterTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/json/JsonWriterTest.java
@@ -44,6 +44,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -116,12 +117,15 @@ public class JsonWriterTest {
     public void testOnSource() throws Exception {
         JsonWriter writer = new JsonWriter(job(), file);
         try {
+            writer.writeStart();
             writer.onSource(source());
+            writer.writeEnd();
         } finally {
             writer.close();
         }
         String content = TestIoUtil.readFileContent(file);
         Map<String, Object> jsonMap = stringToJsonMap(content);
+        jsonMap = ((List<Map<String, Object>>)jsonMap.get("source_files")).get(0);
         assertEquals("Foo.java", jsonMap.get("name"));
         assertEquals("public class Foo { }", jsonMap.get("source"));
         assertEquals(1, ((Collection<?>) jsonMap.get("coverage")).size());


### PR DESCRIPTION
We have a use case where we have separate coverage reports from integration tests and unit tests for both javascript and java. This means the same file will appear in several reports. Current plugin implementation only counts the first occurrence of a file. This pull request keeps sources in memory until all reports have been parsed and only writes them in the end to enable merging the results.

Use case here: https://bob.nitorio.us/jenkins/job/willow-integrationtests/
