### PR TITLE
#95 Fix for NPE if Content-Type is null

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/httpclient/CoverallsClient.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/httpclient/CoverallsClient.java
@@ -93,10 +93,13 @@ public class CoverallsClient {
     private CoverallsResponse parseResponse(final HttpResponse response) throws ProcessingException, IOException {
         HttpEntity entity = response.getEntity();
         ContentType contentType = ContentType.getOrDefault(entity);
+        if (contentType.getCharset() == null) {
+            throw new ProcessingException(getResponseErrorMessage(response, "Response doesn't contain Content-Type header"));
+        }
         InputStreamReader reader = null;
         try {
             if (response.getStatusLine().getStatusCode() >= HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-                throw new IOException("Coveralls API interal error");
+                throw new IOException("Coveralls API internal error");
             }
             reader = new InputStreamReader(entity.getContent(), contentType.getCharset());
             CoverallsResponse cr = objectMapper.readValue(reader, CoverallsResponse.class);

--- a/src/test/java/org/eluder/coveralls/maven/plugin/httpclient/CoverallsClientTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/httpclient/CoverallsClientTest.java
@@ -27,9 +27,12 @@ package org.eluder.coveralls.maven.plugin.httpclient;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
+import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -51,6 +54,7 @@ import java.io.InputStream;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -130,6 +134,26 @@ public class CoverallsClientTest {
         when(httpResponseMock.getStatusLine()).thenReturn(statusLine);
         when(httpResponseMock.getEntity()).thenReturn(httpEntityMock);
         when(httpEntityMock.getContent()).thenThrow(IOException.class);
+        CoverallsClient client = new CoverallsClient("http://test.com/coveralls", httpClientMock, new ObjectMapper());
+        client.submit(file);
+    }
+
+    @Test(expected = ProcessingException.class)
+    public void testParseEntityWithoutContentType() throws Exception {
+        StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, 400, "Bad Request");
+        when(httpResponseMock.getStatusLine()).thenReturn(statusLine);
+        when(httpClientMock.execute(any(HttpUriRequest.class))).thenReturn(httpResponseMock);
+        when(httpResponseMock.getEntity()).thenReturn(httpEntityMock);
+        Header header = mock(Header.class);
+        HeaderElement element = mock(HeaderElement.class);
+        when(element.getName()).thenReturn("HeaderName");
+        NameValuePair pair = mock(NameValuePair.class);
+        when(pair.getName()).thenReturn("name");
+        when(pair.getValue()).thenReturn("value");
+        when(element.getParameters()).thenReturn(new NameValuePair[] { pair } );
+        when(header.getElements()).thenReturn(new HeaderElement[] { element } );
+        when(httpEntityMock.getContentType()).thenReturn(header);
+        when(httpEntityMock.getContent()).thenReturn(coverallsResponse(new CoverallsResponse("success", false, "")));
         CoverallsClient client = new CoverallsClient("http://test.com/coveralls", httpClientMock, new ObjectMapper());
         client.submit(file);
     }


### PR DESCRIPTION
#95 Fix for NPE if Content-Type is null
Now, instead of NPE we will see following (example):
```
org.eluder.coveralls.maven.plugin.ProcessingException: Report submission to Coveralls API failed with HTTP status 400: Bad Request (Response doesn't contain Content-Type header)
```
With real error code and error message