### PR TITLE
ommit out of bounds covered lines

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/domain/Source.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 
 public final class Source implements JsonObject {
     
@@ -87,11 +88,15 @@ public final class Source implements JsonObject {
     }
     
     public void addCoverage(final int lineNumber, final Integer coverage) {
+
+         SystemStreamLog log = new SystemStreamLog();
+
         int index = lineNumber - 1;
         if (index >= this.coverage.length) {
-            throw new IllegalArgumentException("Line number " + lineNumber + " is greater than the source file " + name + " size");
+            log.error ("Line number " + lineNumber + " is greater than the source file " + name + " size");
+        } else {
+            this.coverage[index] = coverage;
         }
-        this.coverage[lineNumber - 1] = coverage;
     }
 
     public Source merge(final Source source) {

--- a/src/test/java/org/eluder/coveralls/maven/plugin/domain/SourceTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/domain/SourceTest.java
@@ -41,7 +41,7 @@ public class SourceTest {
         assertArrayEquals(new Integer[] { 3, null, 3, null }, source.getCoverage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddCoverageForSourceOutOfBounds() {
         Source source = new Source("src/main/java/Hello.java", "public class Hello {\n  \n}\n", "E8BD88CF0BDB77A6408234FD91FD22C3");
         source.addCoverage(5, 1);


### PR DESCRIPTION
As a mixure between scala, traits and jacoco can end in coverage info on lines greater than the source file, it would be nice to not include that coverage, lust log the error and keep on going.