### PR TITLE
Added support for Wercker

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
@@ -54,6 +54,7 @@ import org.eluder.coveralls.maven.plugin.service.Jenkins;
 import org.eluder.coveralls.maven.plugin.service.ServiceSetup;
 import org.eluder.coveralls.maven.plugin.service.Shippable;
 import org.eluder.coveralls.maven.plugin.service.Travis;
+import org.eluder.coveralls.maven.plugin.service.Wercker;
 import org.eluder.coveralls.maven.plugin.source.SourceCallback;
 import org.eluder.coveralls.maven.plugin.source.SourceLoader;
 import org.eluder.coveralls.maven.plugin.source.UniqueSourceCallback;
@@ -307,6 +308,7 @@ public class CoverallsReportMojo extends AbstractMojo {
         services.add(new Jenkins(env));
         services.add(new Bamboo(env));
         services.add(new Appveyor(env));
+        services.add(new Wercker(env));
         services.add(new General(env));
         return services;
     }

--- a/src/main/java/org/eluder/coveralls/maven/plugin/service/Wercker.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/service/Wercker.java
@@ -1,0 +1,71 @@
+package org.eluder.coveralls.maven.plugin.service;
+
+import java.util.Map;
+
+/*
+ * #[license]
+ * coveralls-maven-plugin
+ * %%
+ * Copyright (C) 2013 - 2016 Tapio Rautonen
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * %[license]
+ */
+
+/**
+ * Service implementation for Wercker CI.
+ * <p>
+ * http://wercker.com/
+ */
+public class Wercker extends AbstractServiceSetup {
+
+    public static final String WERCKER_NAME = "wercker";
+    public static final String WERCKER_BUILD_URL = "WERCKER_RUN_URL";
+    public static final String WERCKER_BRANCH = "WERCKER_GIT_BRANCH";
+
+    public Wercker(final Map<String, String> env) {
+        super(env);
+    }
+
+    @Override
+    public boolean isSelected() {
+        return getProperty(WERCKER_BRANCH) != null;
+    }
+
+    @Override
+    public String getName() {
+        return WERCKER_NAME;
+    }
+
+    @Override
+    public String getJobId() {
+        final String buildUrl = getBuildUrl();
+        return buildUrl.substring(buildUrl.lastIndexOf("/") + 1);
+    }
+
+    @Override
+    public String getBuildUrl() {
+        return getProperty(WERCKER_BUILD_URL);
+    }
+
+    @Override
+    public String getBranch() {
+        return getProperty(WERCKER_BRANCH);
+    }
+}

--- a/src/test/java/org/eluder/coveralls/maven/plugin/service/WerckerTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/service/WerckerTest.java
@@ -1,0 +1,71 @@
+package org.eluder.coveralls.maven.plugin.service;
+
+/*
+ * #[license]
+ * coveralls-maven-plugin
+ * %%
+ * Copyright (C) 2013 - 2016 Tapio Rautonen
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * %[license]
+ */
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WerckerTest {
+    
+    private Map<String, String> env() {
+        Map<String, String> env = new HashMap<String, String>();
+        env.put("WERCKER_RUN_URL", "https://app.wercker.com/build/123456789");
+        env.put("WERCKER_GIT_BRANCH", "master");
+        return env;
+    }
+    
+    @Test
+    public void testIsSelectedForNothing() {
+        assertFalse(new Wercker(new HashMap<String, String>()).isSelected());
+    }
+    
+    @Test
+    public void testIsSelectedForTravis() {
+        assertTrue(new Wercker(env()).isSelected());
+    }
+    
+    @Test
+    public void testGetName() {
+        assertEquals("wercker", new Wercker(env()).getName());
+    }
+    
+    @Test
+    public void testGetJobId() {
+        assertEquals("123456789", new Wercker(env()).getJobId());
+    }
+
+    @Test
+    public void testGetBranch() {
+        assertEquals("master", new Wercker(env()).getBranch());
+    }
+}


### PR DESCRIPTION
Right now using this plugin with Wercker is messing up things in Coveralls, since it takes the commit's SHA1 as branch name. The result is that you have hundreds of branches with exactly one commit. You can find an example [here](https://coveralls.io/repos/85458/builds) (we ignored this problem for quite a while).

It would be great if you could incorporate this fix in a future release (soon? :) ).

Werckers environment variables are described [here](http://devcenter.wercker.com/docs/environment-variables/available-env-vars.html).

Btw. is there a way to really test this (without having to push it to maven central)? I'm pretty sure that it works, but you never know... ;)