### PR TITLE
Fixed Wercker environment variables

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/service/Wercker.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/service/Wercker.java
@@ -36,7 +36,9 @@ import java.util.Map;
 public class Wercker extends AbstractServiceSetup {
 
     public static final String WERCKER_NAME = "wercker";
-    public static final String WERCKER_BUILD_URL = "WERCKER_RUN_URL";
+    public static final String WERCKER = "WERCKER";
+    public static final String WERCKER_BUILD_ID = "WERCKER_BUILD_ID";
+    public static final String WERCKER_BUILD_URL = "WERCKER_BUILD_URL";
     public static final String WERCKER_BRANCH = "WERCKER_GIT_BRANCH";
 
     public Wercker(final Map<String, String> env) {
@@ -45,7 +47,7 @@ public class Wercker extends AbstractServiceSetup {
 
     @Override
     public boolean isSelected() {
-        return getProperty(WERCKER_BRANCH) != null;
+        return "true".equalsIgnoreCase(getProperty(WERCKER));
     }
 
     @Override
@@ -55,8 +57,7 @@ public class Wercker extends AbstractServiceSetup {
 
     @Override
     public String getJobId() {
-        final String buildUrl = getBuildUrl();
-        return buildUrl.substring(buildUrl.lastIndexOf("/") + 1);
+        return getProperty(WERCKER_BUILD_ID);
     }
 
     @Override

--- a/src/test/java/org/eluder/coveralls/maven/plugin/service/WerckerTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/service/WerckerTest.java
@@ -39,7 +39,9 @@ public class WerckerTest {
     
     private Map<String, String> env() {
         Map<String, String> env = new HashMap<String, String>();
-        env.put("WERCKER_RUN_URL", "https://app.wercker.com/build/123456789");
+        env.put("WERCKER", "true");
+        env.put("WERCKER_BUILD_URL", "https://app.wercker.com/build/123456789");
+        env.put("WERCKER_BUILD_ID", "123456789");
         env.put("WERCKER_GIT_BRANCH", "master");
         return env;
     }
@@ -50,7 +52,7 @@ public class WerckerTest {
     }
     
     @Test
-    public void testIsSelectedForTravis() {
+    public void testIsSelectedForWercker() {
         assertTrue(new Wercker(env()).isSelected());
     }
     
@@ -62,6 +64,11 @@ public class WerckerTest {
     @Test
     public void testGetJobId() {
         assertEquals("123456789", new Wercker(env()).getJobId());
+    }
+
+    @Test
+    public void testGetBuildUrl() {
+        assertEquals("https://app.wercker.com/build/123456789", new Wercker(env()).getBuildUrl());
     }
 
     @Test


### PR DESCRIPTION
Unfortunately the implementation in #99 failed because the documentation of wercker seems to list some wrong environment variables.
I was able to retrieve the real variables from the wercker/maven debug output, so this time it should really work.
