### PR TITLE
Remove dependency on java.xml.bind for ease of use with jdk9 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>httpmime</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -124,7 +129,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.4</version>
+      <version>3.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/eluder/coveralls/maven/plugin/util/Md5DigestInputStream.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/util/Md5DigestInputStream.java
@@ -26,11 +26,11 @@ package org.eluder.coveralls.maven.plugin.util;
  * %[license]
  */
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.apache.commons.codec.binary.Hex;
 
 public class Md5DigestInputStream extends DigestInputStream {
 
@@ -39,6 +39,6 @@ public class Md5DigestInputStream extends DigestInputStream {
     }
 
     public String getDigestHex() {
-        return DatatypeConverter.printHexBinary(getMessageDigest().digest());
+        return new String(Hex.encodeHex(getMessageDigest().digest(),false));
     }
 }

--- a/src/test/java/org/eluder/coveralls/maven/plugin/util/TestIoUtil.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/util/TestIoUtil.java
@@ -26,9 +26,6 @@ package org.eluder.coveralls.maven.plugin.util;
  * %[license]
  */
 
-import org.codehaus.plexus.util.IOUtil;
-
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -38,8 +35,9 @@ import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.codehaus.plexus.util.IOUtil;
 
 public class TestIoUtil {
 
@@ -77,9 +75,7 @@ public class TestIoUtil {
     }
 
     public static String getMd5DigestHex(final String content) throws NoSuchAlgorithmException {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] digest = md.digest(content.getBytes());
-        return DatatypeConverter.printHexBinary(digest);
+        return DigestUtils.md5Hex(content).toUpperCase();
     }
 
     private static URL getResourceUrl(final String resource) {


### PR DESCRIPTION
This PR Fixes #112 . 
It's easier to add a dependency than make sure that the module gets added to MAVEN_OPTS.  

1. Add dependency on Apache Commons Codec for hex util
2. Commons codec to generate hex strings from digests.
3. Update commons-lang plug in to current version (just on principle )

Transfer of intellectual property rights and Disclaimer of liability:

1. Unless required by applicable law this  software is provided on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

2. To the extent that any intellectual property rights may inhere in the  changes associated with this pull request, I herein assert that I am the owner  of any such rights, and hereby transfer any such rights to Tapio Rautonen. 