### PR TITLE
Ability to specify exclusions for ScanSourceLoader

### DIFF
--- a/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
@@ -201,6 +201,12 @@ public class CoverallsReportMojo extends AbstractMojo {
     protected boolean scanForSources;
 
     /**
+     * A list of exclude patterns to exclude while scanning for sources.
+     */
+    @Parameter(property = "scanExclusions")
+    protected List<String> scanExclusions;
+
+    /**
      * Base directory of the project.
      */
     @Parameter(property = "coveralls.basedir", defaultValue = "${project.basedir}")
@@ -286,6 +292,7 @@ public class CoverallsReportMojo extends AbstractMojo {
         return new SourceLoaderFactory(job.getGit().getBaseDir(), project, sourceEncoding)
                 .withSourceDirectories(sourceDirectories)
                 .withScanForSources(scanForSources)
+                .withScanExclusions(scanExclusions)
                 .createSourceLoader();
     }
 

--- a/src/main/java/org/eluder/coveralls/maven/plugin/source/ScanSourceLoader.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/source/ScanSourceLoader.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ScanSourceLoader extends AbstractSourceLoader {
@@ -44,9 +45,12 @@ public class ScanSourceLoader extends AbstractSourceLoader {
 
     private final File sourceDirectory;
 
-    public ScanSourceLoader(final File base, final File sourceDirectory, final String sourceEncoding) {
+    private final List<String> scanExclusions;
+
+    public ScanSourceLoader(final File base, final File sourceDirectory, final String sourceEncoding, final List<String> scanExclusions) {
         super(base.toURI(), sourceDirectory.toURI(), sourceEncoding);
         this.sourceDirectory = sourceDirectory;
+        this.scanExclusions = scanExclusions;
     }
 
     @Override
@@ -66,6 +70,9 @@ public class ScanSourceLoader extends AbstractSourceLoader {
         if (!cache.containsKey(extension)) {
             DirectoryScanner scanner = new DirectoryScanner();
             scanner.setBasedir(sourceDirectory);
+            if (scanExclusions != null) {
+                scanner.setExcludes(scanExclusions.toArray(new String[0]));
+            }
             scanner.addDefaultExcludes();
             scanner.setIncludes(new String[] {"**/*." + extension});
             scanner.scan();

--- a/src/main/java/org/eluder/coveralls/maven/plugin/util/SourceLoaderFactory.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/util/SourceLoaderFactory.java
@@ -43,6 +43,7 @@ public class SourceLoaderFactory {
     private final String sourceEncoding;
     private List<File> sourceDirectories;
     private boolean scanForSources;
+    private List<String> scanExclusions;
 
     public SourceLoaderFactory(final File baseDir, final MavenProject project, final String sourceEncoding) {
         this.baseDir = baseDir;
@@ -57,6 +58,11 @@ public class SourceLoaderFactory {
 
     public SourceLoaderFactory withScanForSources(final boolean scanForSources) {
         this.scanForSources = scanForSources;
+        return this;
+    }
+
+    public SourceLoaderFactory withScanExclusions(final List<String> scanExclusions) {
+        this.scanExclusions = scanExclusions;
         return this;
     }
 
@@ -83,7 +89,7 @@ public class SourceLoaderFactory {
         if (scanForSources) {
             for (File directory: directories) {
                 if (directory.exists() && directory.isDirectory()) {
-                    ScanSourceLoader scanSourceLoader = new ScanSourceLoader(baseDir, directory, sourceEncoding);
+                    ScanSourceLoader scanSourceLoader = new ScanSourceLoader(baseDir, directory, sourceEncoding, scanExclusions);
                     multiSourceLoader.add(scanSourceLoader);
                 }
             }

--- a/src/test/java/org/eluder/coveralls/maven/plugin/source/ScanSourceLoaderTest.java
+++ b/src/test/java/org/eluder/coveralls/maven/plugin/source/ScanSourceLoaderTest.java
@@ -54,14 +54,14 @@ public class ScanSourceLoaderTest {
     
     @Test
     public void testMissingSourceFileFromDirectory() throws Exception {
-        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8");
+        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8", null);
         assertNull(sourceLoader.load("Foo.java"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidSourceFile() throws Exception {
         File subFolder = folder.newFolder();
-        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8");
+        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8", null);
         sourceLoader.load(subFolder.getName());
     }
 
@@ -72,7 +72,7 @@ public class ScanSourceLoaderTest {
         File fileB = new File(dir, "BFile.java");
         TestIoUtil.writeFileContent("public class Foo {\r\n    \n}\r", fileA);
         TestIoUtil.writeFileContent("public class Foo {\r\n    \n}\r", fileB);
-        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8");
+        ScanSourceLoader sourceLoader = new ScanSourceLoader(folder.getRoot(), folder.getRoot(), "UTF-8", null);
         Source sourceA = sourceLoader.load(fileA.getName());
         assertEquals("level1/level2/level3/AFile.java", sourceA.getName());
         assertEquals("2AC359C9A152FD7CD79C4EB147069224", sourceA.getDigest());


### PR DESCRIPTION
Sometimes its handy to be able to filter the scanned sources, i.e. generated sources.