### PR TITLE
#137 Fix to run with java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,16 @@
       <version>2.25.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.2</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
With these additional dependencies the plugin runs with java 11.
Please merge it and create a new release.
Many thanks and regards,
Markus
